### PR TITLE
Always regenerate CJS shim packages in postinstall script

### DIFF
--- a/scripts/fix-yarn-cjs-aliases.cjs
+++ b/scripts/fix-yarn-cjs-aliases.cjs
@@ -13,9 +13,6 @@ function ensureReexportPackage(targetName, aliasName) {
   const targetDir = path.join(nodeModules, targetName);
   const aliasDir = path.join(nodeModules, aliasName);
 
-  if (fs.existsSync(targetDir)) {
-    return;
-  }
   if (!fs.existsSync(aliasDir)) {
     return;
   }


### PR DESCRIPTION
### Motivation
- Prevent CJS `require()` failures (e.g. `wide-align` -> `string-width`) by ensuring postinstall always writes CJS shim packages when the `*-cjs` alias exists.

### Description
- Remove the early-return in `scripts/fix-yarn-cjs-aliases.cjs` so the script now always (re)creates the shim `node_modules/<package>` that re-exports the corresponding `*-cjs` alias when that alias is present.

### Testing
- Ran unit tests with `node --test test/*.spec.mjs` (`npm run test:unit`) and they passed.
- Attempted full build (`npm run build`) and dependency install but the environment failed to fetch packages from the registry (HTTP 403), so build/install could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d638b7fadc8329bf8b61384c36a990)