### PR TITLE
ci: pin GitHub Actions test workflow to Yarn Classic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Activate Yarn Classic
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by Yarn major-version / lockfile mismatches by ensuring the Actions runner uses Yarn Classic (the lockfile in this repo is Yarn v1). 

### Description
- Update `.github/workflows/test.yml` to add `cache-dependency-path: yarn.lock` and to enable Corepack and explicitly `corepack prepare yarn@1.22.22 --activate` before running `yarn install --frozen-lockfile` so the workflow uses Yarn Classic deterministically. 

### Testing
- Ran the repository test workflow locally with `npm run test` (which executes `node --test test/*.spec.mjs` and a Nuxt production `build`) and the tests and build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de46c06f808329a74623fe2152cbca)